### PR TITLE
fix(render): apply configured helm api_versions

### DIFF
--- a/internal/render/helm.go
+++ b/internal/render/helm.go
@@ -68,6 +68,13 @@ func (r *HelmRenderer) renderSDK(ctx context.Context, app discovery.DiscoveredAp
 		}
 	}
 
+	// Advertise extra API versions so charts that gate resources on
+	// .Capabilities.APIVersions.Has (e.g. CRDs installed by other apps, such
+	// as monitoring.coreos.com/v1 for ServiceMonitors) render without error.
+	if len(r.cfg.Render.Helm.APIVersions) > 0 {
+		install.APIVersions = append(install.APIVersions, r.cfg.Render.Helm.APIVersions...)
+	}
+
 	var chartPath string
 	if app.RootPath != "" {
 		// Local chart

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -51,6 +51,36 @@ func TestHelmRenderer_LocalChart(t *testing.T) {
 	assert.True(t, hasExpectedKind, "expected at least one k8s resource kind, got: %v", kinds)
 }
 
+func TestHelmRenderer_APIVersions(t *testing.T) {
+	chartPath := testdataPath("capability-chart")
+	app := discovery.DiscoveredApp{
+		Name:        "capability-chart",
+		Framework:   discovery.FrameworkPlain,
+		Renderer:    discovery.RendererHelm,
+		RootPath:    chartPath,
+		ReleaseName: "capability-chart",
+		Namespace:   "default",
+	}
+
+	// Without the extra API version advertised, the chart hard-fails its
+	// capability guard (mirrors the Traefik ServiceMonitor failure).
+	cfg := defaultCfg()
+	_, err := New(app, cfg).Render(context.Background(), app)
+	require.Error(t, err, "expected render to fail when monitoring.coreos.com/v1 is not advertised")
+
+	// Advertising it via config lets the chart render the ServiceMonitor.
+	cfg = defaultCfg()
+	cfg.Render.Helm.APIVersions = []string{"monitoring.coreos.com/v1"}
+	manifests, err := New(app, cfg).Render(context.Background(), app)
+	require.NoError(t, err)
+
+	kinds := make(map[string]bool)
+	for _, m := range manifests {
+		kinds[m.Kind] = true
+	}
+	assert.True(t, kinds["ServiceMonitor"], "expected a ServiceMonitor, got: %v", kinds)
+}
+
 func TestKustomizeRenderer_Base(t *testing.T) {
 	basePath := testdataPath("kustomize-overlay/base")
 	app := discovery.DiscoveredApp{

--- a/test/testdata/capability-chart/Chart.yaml
+++ b/test/testdata/capability-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: capability-chart
+description: Chart that gates a resource on an extra API version capability
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/test/testdata/capability-chart/templates/servicemonitor.yaml
+++ b/test/testdata/capability-chart/templates/servicemonitor.yaml
@@ -1,0 +1,11 @@
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- fail "ERROR: You have to deploy monitoring.coreos.com/v1 first" }}
+{{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}


### PR DESCRIPTION
## Problem

The `render.helm.api_versions` config field is defined (`internal/config/config.go`) and documented (`docs/configuration.md`), but it was never wired into the renderer — so setting it has no effect.

This means charts that gate resources on `.Capabilities.APIVersions.Has "<group>/<version>"` cannot be rendered. A common example is the Traefik chart with `metrics.prometheus.serviceMonitor.enabled: true`, whose `servicemonitor.yaml` hard-`fail`s unless `monitoring.coreos.com/v1` (the Prometheus Operator CRD, installed by a *different* app) is advertised:

```
WRN render failed, skipping app=traefik err="helm template \"traefik\": execution error at (traefik/templates/servicemonitor.yaml:5:10): ERROR: You have to deploy monitoring.coreos.com/v1 first"
```

The app is then skipped and never linted. Setting the documented config does not help:

```yaml
render:
  helm:
    api_versions: ["monitoring.coreos.com/v1"]
```

## Cause

In `internal/render/helm.go`, `renderSDK` wires `install.IncludeCRDs` and `install.KubeVersion` from config, but never sets `install.APIVersions`. The Helm v4 SDK appends `install.APIVersions` onto `Capabilities.APIVersions` during render (`pkg/action/install.go`), so threading the config value through resolves the capability check.

## Fix

Apply the configured `api_versions` onto `install.APIVersions`.

## Test

Adds `test/testdata/capability-chart`, a chart that gates a `ServiceMonitor` on `monitoring.coreos.com/v1` (mirroring Traefik). `TestHelmRenderer_APIVersions` asserts the render **fails** without the config and **succeeds** (producing the `ServiceMonitor`) with it.

## Notes

- No doc change needed — `docs/configuration.md` already lists `api_versions`.
- The subprocess renderer (`helm_subprocess.go`) also doesn't pass `--api-versions`, but it doesn't currently receive `cfg`. The SDK path is the default (`subprocess_fallback: false`), so this PR fixes that path only; happy to extend to the subprocess path in a follow-up if you'd like.
